### PR TITLE
fix(audit): disable audit of LogsAmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ master
 * Add TravisCI matrix
 * Fix Coveralls tool export
 * Fix badges
+* Disable audit of Log (cf. https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/audit.html)

--- a/Resources/config/sonata_admin.xml
+++ b/Resources/config/sonata_admin.xml
@@ -9,7 +9,8 @@
             <argument />
             <argument />
             <argument>Ekino\DataProtectionBundle\Controller\LogsAdminController</argument>
-            <tag name="sonata.admin" manager_type="orm" label="Logs" />
+            <tag name="sonata.admin" manager_type="orm" label="Logs" audit="false" />
+            <!-- disable audit https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/audit.html -->
         </service>
 
         <service id="Ekino\DataProtectionBundle\Controller\LogsAdminController">


### PR DESCRIPTION
if audit is activated by default in sonata config (sonata_doctrine_orm_admin.audit.force:true), service  'Ekino\DataProtectionBundle\Admin\LogsAdmin' must be ignored by AddAuditEntityCompilerPass of doctrine-orm-admin-bundle to avoid an error because this admin has not a class.