### PR TITLE
Remove deprecation about configuration tree builder without a root node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ master
 * Fix Coveralls tool export
 * Fix badges
 * Disable audit of Log (cf. https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/audit.html)
+* Remove deprecation about configuration tree builder without a root node

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,8 +28,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode    = $treeBuilder->root('ekino_data_protection');
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder();
+            $rootNode    = $treeBuilder->root('ekino_data_protection');
+        } else {
+            $treeBuilder = new TreeBuilder('ekino_data_protection');
+            $rootNode    = $treeBuilder->getRootNode();
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
related to https://github.com/symfony/config/blob/a17a2aea43950ce83a0603ed301bac362eb86870/Definition/Builder/TreeBuilder.php#L30