### PR TITLE
fix(dep): Make symfony dependencies explicit, add sonata twig as dev & remove SonataCoreBundle occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ master
 * Drop support for PHP 7.1
 * Add PHP 7.4 in CI
 * Upgrade PhpUnit to 8
+* Make symfony dependencies explicit, add sonata twig as dev dep & remove SonataCoreBundle occurrence
 
 v1.1.0
 ------

--- a/Resources/views/LogsAdmin/decrypt.html.twig
+++ b/Resources/views/LogsAdmin/decrypt.html.twig
@@ -3,7 +3,7 @@
 
 {% block sonata_admin_content %}
     {% block notice %}
-        {% include '@SonataCore/FlashMessage/render.html.twig' %}
+        {% include '@SonataTwig/FlashMessage/render.html.twig' %}
     {% endblock notice %}
 
     {{ form_start(form) }}

--- a/Tests/Admin/LogsAdminTest.php
+++ b/Tests/Admin/LogsAdminTest.php
@@ -36,7 +36,9 @@ class LogsAdminTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->admin = new LogsAdmin('', '', LogsAdminController::class);
+        /** @var class-string<object> $fooClass */
+        $fooClass    = '\Foo';
+        $this->admin = new LogsAdmin('', $fooClass, LogsAdminController::class);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,18 @@
         "symfony/dependency-injection": "~3.4.10|^4.4",
         "symfony/form":                 "~3.3|~4.4",
         "symfony/http-kernel":          "~3.3|~4.4",
-        "symfony/translation":          "~3.3|~4.4"
+        "symfony/options-resolver":     "~3.3|~4.4",
+        "symfony/translation":          "~3.3|~4.4",
+        "symfony/validator":            "~3.3|~4.4"
     },
     "require-dev": {
-        "ekino/phpstan-banned-code":   "^0.2 || ^0.3",
-        "friendsofphp/php-cs-fixer":   "^2.12",
-        "phpstan/phpstan-phpunit":     "^0.12",
-        "phpunit/phpunit":             "^8.5",
-        "sensiolabs/security-checker": "^6.0",
-        "sonata-project/admin-bundle": "3.*"
+        "ekino/phpstan-banned-code":      "^0.2 || ^0.3",
+        "friendsofphp/php-cs-fixer":      "^2.12",
+        "phpstan/phpstan-phpunit":        "^0.12",
+        "phpunit/phpunit":                "^8.5",
+        "sensiolabs/security-checker":    "^6.0",
+        "sonata-project/admin-bundle":    "3.*",
+        "sonata-project/twig-extensions": "1.*"
     },
     "autoload": {
         "psr-4": { "Ekino\\DataProtectionBundle\\": "" },


### PR DESCRIPTION
This MR remove usage of SonataCoreBundle (deprecated bundle and not required anymore by SonataAdminBundle) and replace it by usage of SonataTwigBundle 